### PR TITLE
Hotfix: Added settings argument to preprocess 

### DIFF
--- a/elysia/preprocessing/collection.py
+++ b/elysia/preprocessing/collection.py
@@ -832,6 +832,7 @@ async def _preprocess_async(
                         max_sample_size=max_sample_size,
                         num_sample_tokens=num_sample_tokens,
                         force=force,
+                        settings=settings,
                     ):
                         if (
                             result is not None


### PR DESCRIPTION
There was a small bug related to the `settings` object not being passed down by the `_preprocess_async` function when the logging level of the settings was `<=20`. This adds the argument back as it was missed.