### PR TITLE
fix: litellm dependency <1.76

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "psutil==7.0.0",
     "cryptography>=44.0.3",
     "matplotlib>=3.10.3",
-    "litellm>=1.74.15",
+    "litellm>=1.74.15,<1.76.0",
     "thinc>=8.3.4,<8.4.0",
     "pip>=25.2",
 ]


### PR DESCRIPTION
LiteLLM changed the `models_by_provider` to be a set instead of a list in versions greater than 1.76. This hotfix constrains the `litellm` version to be less than 1.76 to alleviate this error.

Later development will check future changes in LiteLLM to relax the constraint.