### PR TITLE
fix: don't remove all API keys in ElysiaKeyManager

### DIFF
--- a/docs/creating_tools.md
+++ b/docs/creating_tools.md
@@ -136,3 +136,33 @@ All optional arguments you can pass to the `@tool` decorator are:
 - `branch_id` (`str`): the ID of the branch on the tree to add the tool to.
 - `status` (`str`): a custom message to display whilst the tool is running.
 - `end` (`bool`): when `True`, this tool can be the end of the conversation if the decision agent decides it should end after the completion of this tool.
+
+## Environment Variables
+
+Environment variables (stored in `.env` and accessed via `os.getenv(...)` or `os.environ`) are passed down to tools - with some exceptions. Any environment variables whose keys end with the following strings:
+
+- `"api_key"`
+- `"apikey"`
+- `"api_version"`
+- `"api_base"`
+- `"_account_id"`
+- `"_jwt"`
+- `"_access_key_id"`
+- `"_secret_access_key"`
+- `"_region_name"`
+- `"_token"`
+
+Will **NOT** be passed down to tools. This is to ensure that API keys are differentiated between the `Settings` object and the actual `.env` file. For example, if these *were* included in all tool calls, then any LLM calls would use what is in the `.env`, instead of what has been configured in the tree. This is due to the way LiteLLM processes LLM requests via API keys in the environment.
+
+**If you need environment variables like this, or notice your environment variables are going missing**, then consider renaming them (e.g. `my_api_key` -> `my_api_key_`) or including them in the `api_keys` variable in the `Settings` object, via
+
+```python
+from elysia import settings
+settings = Settings()
+settings.configure(
+    api_keys = {
+        "MY_API_KEY": "..."
+    }
+)
+```
+The `MY_API_KEY` will then accessible from `os.environ`. Or, in the Elysia web app, within your API keys section of the config.

--- a/elysia/api/utils/config.py
+++ b/elysia/api/utils/config.py
@@ -122,14 +122,15 @@ class FrontendConfig:
         }
         self.save_location_wcd_url: str = os.getenv("WCD_URL", "")
         self.save_location_wcd_api_key: str = os.getenv("WCD_API_KEY", "")
-        self.save_location_weaviate_is_local: bool = os.getenv(
-            "WEAVIATE_IS_LOCAL", "False"
-        ) == "True"
+        self.save_location_weaviate_is_local: bool = (
+            os.getenv("WEAVIATE_IS_LOCAL", "False") == "True"
+        )
         self.save_location_local_weaviate_port: int = int(
             os.getenv("LOCAL_WEAVIATE_PORT", 8080)
         )
-        self.save_location_local_weaviate_grpc_port: int = int(os.getenv("LOCAL_WEAVIATE_GRPC_PORT", 50051)
-        )   
+        self.save_location_local_weaviate_grpc_port: int = int(
+            os.getenv("LOCAL_WEAVIATE_GRPC_PORT", 50051)
+        )
         self.save_location_client_manager: ClientManager = ClientManager(
             wcd_url=self.save_location_wcd_url,
             wcd_api_key=self.save_location_wcd_api_key,
@@ -199,13 +200,19 @@ class FrontendConfig:
             self.save_location_wcd_api_key = kwargs["save_location_wcd_api_key"]
             reload_client_manager = True
         if "save_location_weaviate_is_local" in kwargs:
-            self.save_location_weaviate_is_local = kwargs["save_location_weaviate_is_local"]
+            self.save_location_weaviate_is_local = kwargs[
+                "save_location_weaviate_is_local"
+            ]
             reload_client_manager = True
         if "save_location_local_weaviate_port" in kwargs:
-            self.save_location_local_weaviate_port = kwargs["save_location_local_weaviate_port"]
+            self.save_location_local_weaviate_port = kwargs[
+                "save_location_local_weaviate_port"
+            ]
             reload_client_manager = True
         if "save_location_local_weaviate_grpc_port" in kwargs:
-            self.save_location_local_weaviate_grpc_port = kwargs["save_location_local_weaviate_grpc_port"]
+            self.save_location_local_weaviate_grpc_port = kwargs[
+                "save_location_local_weaviate_grpc_port"
+            ]
             reload_client_manager = True
         if "save_trees_to_weaviate" in kwargs:
             self.config["save_trees_to_weaviate"] = kwargs["save_trees_to_weaviate"]

--- a/elysia/config.py
+++ b/elysia/config.py
@@ -347,6 +347,7 @@ class Settings:
                 - local_weaviate_port (int): The port to use for the local Weaviate cluster.
                 - local_weaviate_grpc_port (int): The gRPC port to use for the local Weaviate cluster.
                 - logging_level (str): The logging level to use. e.g. "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
+                - api_keys (dict): A dictionary of API keys to set. E.g. `{"openai_apikey": "..."}`.
                 - use_feedback (bool): EXPERIMENTAL. Whether to use feedback from previous runs of the tree.
                     If True, the tree will use TrainingUpdate objects that have been saved in previous runs of the decision tree.
                     These are implemented via few-shot examples for the decision node.

--- a/elysia/config.py
+++ b/elysia/config.py
@@ -115,6 +115,7 @@ def is_api_key(key: str) -> bool:
         or key.lower().endswith("_access_key_id")
         or key.lower().endswith("_secret_access_key")
         or key.lower().endswith("_region_name")
+        or key.lower().endswith("_token")
     )
 
 
@@ -627,15 +628,44 @@ class ElysiaKeyManager:
         # save existing env
         self.existing_env = deepcopy(os.environ)
 
-        # blank out the environ except for certain values
-        os.environ = {
-            "MODEL_API_BASE": self.settings.MODEL_API_BASE,
-            "WCD_URL": self.settings.WCD_URL,
-            "WCD_API_KEY": self.settings.WCD_API_KEY,
-            "WEAVIATE_IS_LOCAL": str(self.settings.WEAVIATE_IS_LOCAL),
-            "LOCAL_WEAVIATE_PORT": str(self.settings.LOCAL_WEAVIATE_PORT),
-            "LOCAL_WEAVIATE_GRPC_PORT": str(self.settings.LOCAL_WEAVIATE_GRPC_PORT),
-        }
+        items_to_remove = []
+        for key in os.environ:
+            if is_api_key(key):
+                items_to_remove.append(key)
+
+        for key in items_to_remove:
+            del os.environ[key]
+
+        if (
+            "MODEL_API_BASE" in dir(self.settings)
+            and self.settings.MODEL_API_BASE is not None
+        ):
+            os.environ["MODEL_API_BASE"] = self.settings.MODEL_API_BASE
+
+        if "WCD_URL" in dir(self.settings) and self.settings.WCD_URL is not None:
+            os.environ["WCD_URL"] = self.settings.WCD_URL
+        if (
+            "WCD_API_KEY" in dir(self.settings)
+            and self.settings.WCD_API_KEY is not None
+        ):
+            os.environ["WCD_API_KEY"] = self.settings.WCD_API_KEY
+        if (
+            "WEAVIATE_IS_LOCAL" in dir(self.settings)
+            and self.settings.WEAVIATE_IS_LOCAL is not None
+        ):
+            os.environ["WEAVIATE_IS_LOCAL"] = str(self.settings.WEAVIATE_IS_LOCAL)
+        if (
+            "LOCAL_WEAVIATE_PORT" in dir(self.settings)
+            and self.settings.LOCAL_WEAVIATE_PORT is not None
+        ):
+            os.environ["LOCAL_WEAVIATE_PORT"] = str(self.settings.LOCAL_WEAVIATE_PORT)
+        if (
+            "LOCAL_WEAVIATE_GRPC_PORT" in dir(self.settings)
+            and self.settings.LOCAL_WEAVIATE_GRPC_PORT is not None
+        ):
+            os.environ["LOCAL_WEAVIATE_GRPC_PORT"] = str(
+                self.settings.LOCAL_WEAVIATE_GRPC_PORT
+            )
 
         # update all api keys in env
         for api_key, value in self.settings.API_KEYS.items():

--- a/tests/no_reqs/general/test_keymanager_env_vars_nr.py
+++ b/tests/no_reqs/general/test_keymanager_env_vars_nr.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+
+from elysia.config import Settings
+from fastapi.responses import JSONResponse
+import json
+from elysia.api.dependencies.common import get_user_manager
+from elysia.api.services.user import UserManager
+from weaviate.util import generate_uuid5
+
+from uuid import uuid4
+
+from elysia import tool
+from elysia.tree import Tree
+from elysia.config import ElysiaKeyManager
+
+
+def test_api_keys_are_not_passed_down():
+
+    os.environ["TEST_API_KEY"] = "1234567890"
+    settings = Settings()
+    with ElysiaKeyManager(settings):
+        assert "TEST_API_KEY" not in os.environ
+
+
+def test_modified_api_keys_are_passed_down():
+
+    os.environ["TEST_API_KEY_"] = "1234567890"
+    settings = Settings()
+    with ElysiaKeyManager(settings):
+        assert "TEST_API_KEY_" in os.environ
+
+    settings = Settings()
+    settings.configure(api_keys={"TEST_API_KEY": "1234567890"})
+    with ElysiaKeyManager(settings):
+        assert "TEST_API_KEY" in os.environ

--- a/tests/requires_env/general/test_chunking.py
+++ b/tests/requires_env/general/test_chunking.py
@@ -180,10 +180,7 @@ async def test_correct_vectoriser_new():
     ]
 
     # create collection with vectoriser
-    full_vectoriser = Configure.Vectors.text2vec_openai(
-        model="text-embedding-3-large",
-        dimensions=512,
-    )
+    full_vectoriser = Configure.Vectors.text2vec_openai(model="text-embedding-3-small")
     async with client_manager.connect_to_async_client() as client:
         collection_full = await client.collections.create(
             collection_name_full,


### PR DESCRIPTION
Previously, all environment variables were overwritten inside any LLM call or tool call. Now only API keys that match a certain pattern will be removed during these calls. So user-set environment variables necessary for other purposes (such as #54) will no longer be overwritten.

Updated docs to include reference to those environment variables that will be removed and added advice how to stop it from happening.
