### PR TITLE
fix: default offset of sampled data in preprocessing from 99,999 to 9,999

### DIFF
--- a/elysia/preprocessing/collection.py
+++ b/elysia/preprocessing/collection.py
@@ -455,7 +455,7 @@ async def preprocess_async(
 
         # Randomly sample sample_size objects for the summary
         indices = random.sample(
-            range(min(99_999, len_collection)),
+            range(min(9_999, len_collection)),
             max(min(max_sample_size, len_collection), 1),
         )
 


### PR DESCRIPTION
<!-- Before submitting any PR, please check the contributing guidelines: -->
<!-- https://github.com/weaviate/elysia/blob/main/CONTRIBUTING.md -->

## 📝 Changes Description

This PR contains the following changes:

- Changed the maximum index of data from 99,999 to 9,999 in collection preprocessing. [The default value in Weaviate for `QUERY_MAXIMUM_RESULTS` is 10,000](https://docs.weaviate.io/deploy/configuration/env-vars#general), causing pagination errors if the `offset` in `fetch_objects` is above this. 

<!-- ### Related Issue (Optional) -->

<!-- This PR addresses Issue #XX -->

## ✅ Contributor Checklist

<!--  -->
- [X] `no_reqs` tests are passing locally
- [X] `requires_env` tests are passing locally (optional - see [Testing guidelines](https://github.com/weaviate/elysia?tab=contributing-ov-file#testing))
- [X] You agree to Weaviate's [Contributor License Agreement](https://weaviate.io/service/contributor-license-agreement)

<!-- ## Additional Info (Optional) -->

<!-- Enter your info here -->
