### PR TITLE
fix: 'tuple' has no attribute filters error

### DIFF
--- a/elysia/tools/retrieval/util.py
+++ b/elysia/tools/retrieval/util.py
@@ -480,7 +480,7 @@ def _reformat_incorrect_filters(
         for i, filter in enumerate(filter_bucket.filters):
             if isinstance(filter, FilterBucket):
                 _reformat_incorrect_filters(
-                    filter, collection_property_types, collection_name
+                    [filter], collection_property_types, collection_name
                 )
             else:
 


### PR DESCRIPTION
## 📝 Changes Description

This PR contains the following changes:

* Typo related to checking filters for an error, resulting in an error

### Related Issue 

#66 